### PR TITLE
✦ feat: Add Azure DevOps backend

### DIFF
--- a/docs/src/backends/azure_devops.md
+++ b/docs/src/backends/azure_devops.md
@@ -1,0 +1,29 @@
+# Azure DevOps Backend
+
+**Path**: `issues.backends.azure_devops.Backend`
+
+The Azure DevOps backend creates a work item in a specified Azure DevOps project.
+
+This backend supports screenshot uploads. The screenshot is uploaded as an attachment and linked in the description. The description is rendered as Markdown.
+
+### Options:
+
+-   **SERVER_URL**: Your Azure DevOps server URL (e.g., `https://dev.azure.com/your_organization`). Defaults to `https://dev.azure.com`.
+-   **PROJECT**: The name of your Azure DevOps project.
+-   **TOKEN**: Your Azure DevOps Personal Access Token with `Work Items - Read & Write` permissions.
+
+
+### Example:
+
+```python
+# settings.py
+
+ISSUES = {
+    "BACKEND": "issues.backends.azure_devops.Backend",
+    "OPTIONS": {
+        "SERVER_URL": "https://dev.azure.com/your_organization",
+        "PROJECT": "your_project",
+        "TOKEN": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    }
+}
+```

--- a/docs/src/backends/index.md
+++ b/docs/src/backends/index.md
@@ -4,6 +4,7 @@ Django Issues allows you to integrate with various issue tracking systems throug
 
 Below is a list of the available backends and their specific configuration options:
 
+- [Azure DevOps Backend](./azure_devops.md)
 - [Console Backend](./console.md)
 - [Debug Backend](./debug.md)
 - [Email Backend](./email.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
         - index: backends/index.md
         - Console: backends/console.md
         - Debug: backends/debug.md
+        - Azure Devops: backends/azure_devops.md
         - Email: backends/email.md
         - GitHub: backends/github.md
         - GitLab: backends/gitlab.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ optional-dependencies.github = [
 optional-dependencies.gitlab = [
   "python-gitlab>=6.3",
 ]
-
 urls.Documentation = "https://github.com/saxix/django-issues"
 urls.Homepage = "https://github.com/saxix/django-issues"
 
@@ -90,6 +89,7 @@ type-check = [
   "django-stubs[compatible-mypy]",
   "mypy",
   "types-markdown",
+  "types-requests",
 ]
 
 [tool.hatch]

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,4 +23,5 @@ markers =
     online: mark a test as requiring network access
     gitlab: gitlab specific test
     github: github specific test
+    azure_devops: azure devops specific test
     withoutresponses: disable responses mocking

--- a/src/issues/backends/_base.py
+++ b/src/issues/backends/_base.py
@@ -6,6 +6,8 @@ from issues.forms import IssueFormCleanedData
 if TYPE_CHECKING:
     from issues.types import AuthenticatedHttpRequest
 
+not_provided = object()
+
 
 class IssueData(TypedDict):
     title: str
@@ -19,13 +21,18 @@ class BaseBackend:
     def __init__(self, request: "AuthenticatedHttpRequest") -> None:
         self.request = request
 
-    def get_option(self, name: str) -> Any:
+    def get_issue_types(self) -> list[str]:
+        return self.get_option("TYPES")  # type: ignore[no-any-return]
+
+    def get_option(self, name: str, default: Any = not_provided) -> Any:
         from issues.config import CONFIG
 
         try:
             return CONFIG.OPTIONS[name]
         except KeyError as e:
-            raise IssueError("Issues backend Improperly configured") from e
+            if default == not_provided:
+                raise IssueError("Issues backend Improperly configured") from e
+            return default
 
     def get_context(self) -> dict[str, Any]:
         from issues.config import CONFIG

--- a/src/issues/backends/azure_devops.py
+++ b/src/issues/backends/azure_devops.py
@@ -1,0 +1,80 @@
+import base64
+import io
+import json
+
+import markdown
+import requests
+from django.utils.text import slugify
+from requests.auth import HTTPBasicAuth
+
+from ..forms import IssueFormCleanedData
+from ._base import BaseBackend
+
+
+class Backend(BaseBackend):
+    screenshot_supported = False
+
+    def create_ticket(self, cleaned_data: IssueFormCleanedData) -> bool:
+        server_url = self.get_option("SERVER_URL", "https://dev.azure.com")
+        project = self.get_option("PROJECT")  # encode spaces if any
+        pat = self.get_option("TOKEN")
+
+        work_item_type = cleaned_data["type"]
+
+        url = f"{server_url}/{project}/_apis/wit/workitems/${work_item_type}?api-version=7.1-preview.3"
+
+        headers = {"Content-Type": "application/json-patch+json"}
+        screenshot_url: str = ""
+        md_url = ""
+        screenshot_data = cleaned_data.get("screenshot")
+        if screenshot_data:
+            slug = slugify(cleaned_data["title"])
+            filename = f"{slug}.png"
+
+            image_data = base64.b64decode(screenshot_data.split(",")[1])
+            stream = io.BytesIO(image_data)
+            attachment_url = (
+                f"{server_url}/{project}/_apis/wit/attachments?fileName={filename}&api-version=7.1-preview.3"
+            )
+            response = requests.post(
+                attachment_url,
+                data=stream,
+                auth=("", pat),
+                headers={"Content-Type": "application/octet-stream"},
+                timeout=10,
+            )
+            response.raise_for_status()
+            screenshot_url = response.json()["url"]
+            md_url = f"![aa]({response.json()['url']})"
+
+        description = self.get_description({**cleaned_data, "screenshot_url": md_url})
+        data_issue = [
+            {"op": "add", "path": "/fields/System.Title", "from": None, "value": cleaned_data["title"]},
+            {"op": "add", "path": "/fields/System.Description", "from": None, "value": markdown.markdown(description)},
+        ]
+
+        response = requests.post(
+            url, headers=headers, auth=HTTPBasicAuth("", pat), data=json.dumps(data_issue), timeout=10
+        )
+        if response.status_code == 200:  # noqa: PLR2004
+            issue = response.json()
+            work_item_id = issue["id"]
+            if screenshot_data and screenshot_url:
+                url = f"https://dev.azure.com/{project}/_apis/wit/workitems/{work_item_id}?api-version=7.1-preview.3"
+                data_attachment = [
+                    {
+                        "op": "add",
+                        "path": "/relations/-",
+                        "value": {
+                            "rel": "AttachedFile",
+                            "url": screenshot_url,
+                            "attributes": {"comment": "Adding screenshot as evidence"},
+                        },
+                    }
+                ]
+                response = requests.patch(
+                    url, headers=headers, auth=HTTPBasicAuth("", pat), data=json.dumps(data_attachment), timeout=10
+                )
+                response.raise_for_status()
+            return True
+        return False

--- a/src/issues/config.py
+++ b/src/issues/config.py
@@ -33,6 +33,7 @@ class IssuesConfig:
         "BACKEND": "issues.backends.console.Backend",
         "RENDERER": "html2canvas",  # or rasterizeHTML or dom-to-image
         "ISSUE_TEMPLATE": ISSUE_TEMPLATE,
+        "TYPES": ("bug", "enhancement", "feature", "suggestion"),
         "OPTIONS": {},
     }
 

--- a/tests/backends/test_azure_devops.py
+++ b/tests/backends/test_azure_devops.py
@@ -1,0 +1,65 @@
+import datetime
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+import responses
+
+from issues.backends.azure_devops import Backend as AzureDevopsBackend
+
+if TYPE_CHECKING:
+    from issues.forms import IssueFormCleanedData
+
+
+@pytest.fixture(params=[True, False])
+def screenshot(request, image):
+    if request.param:
+        return image
+    return ""
+
+
+@pytest.fixture
+def backend(rf, settings, admin_user):
+    settings.ISSUES = {
+        "BACKEND": "issues.backends.azure_devops.Backend",
+        "TYPES": ("issue",),
+        "OPTIONS": {
+            "SERVER_URL": os.environ.get("DEVOPS_SERVER_URL", "https://dev.azure.com"),
+            "PROJECT": os.environ.get("DEVOPS_PROJECT", "user/project"),
+            "TOKEN": os.environ.get("DEVOPS_TOKEN", "fake-pat"),
+        },
+    }
+    req = rf.get("/test/", HTTP_REFERER="/from/")
+    req.user = admin_user
+    return AzureDevopsBackend(req)
+
+
+@pytest.mark.azure_devops
+@pytest.mark.online
+def test_create(request, backend: AzureDevopsBackend, screenshot: str):
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    if request.node.get_closest_marker("withoutresponses") is None:
+        responses.add(
+            responses.POST,
+            "https://dev.azure.com/hanarero/Test/_apis/wit/workitems/$issue?api-version=7.1-preview.3",
+            json={"id": 123},
+        )
+        responses.add(
+            responses.POST,
+            f"https://dev.azure.com/hanarero/Test/_apis/wit/attachments?fileName=issue-{timestamp}.png&api-version=7.1-preview.3",
+            json={"url": "https://store/image.png"},
+        )
+        responses.add(
+            responses.PATCH,
+            "https://dev.azure.com/hanarero/Test/_apis/wit/workitems/123?api-version=7.1-preview.3",
+            json={"url": "https://store/image.png"},
+        )
+
+    data: "IssueFormCleanedData" = {
+        "title": f"Issue {timestamp}",
+        "description": "login does no work properly",
+        "screenshot": screenshot,
+        "add_screenshot": bool(screenshot),
+        "type": "issue",
+    }
+    assert backend.create_ticket(data)

--- a/tests/backends/test_azure_devops.py
+++ b/tests/backends/test_azure_devops.py
@@ -38,20 +38,22 @@ def backend(rf, settings, admin_user):
 @pytest.mark.online
 def test_create(request, backend: AzureDevopsBackend, screenshot: str):
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    project = backend.get_option("PROJECT")  # encode spaces if any
+
     if request.node.get_closest_marker("withoutresponses") is None:
         responses.add(
             responses.POST,
-            "https://dev.azure.com/hanarero/Test/_apis/wit/workitems/$issue?api-version=7.1-preview.3",
+            f"https://dev.azure.com/{project}/_apis/wit/workitems/$issue?api-version=7.1-preview.3",
             json={"id": 123},
         )
         responses.add(
             responses.POST,
-            f"https://dev.azure.com/hanarero/Test/_apis/wit/attachments?fileName=issue-{timestamp}.png&api-version=7.1-preview.3",
+            f"https://dev.azure.com/{project}/_apis/wit/attachments?fileName=issue-{timestamp}.png&api-version=7.1-preview.3",
             json={"url": "https://store/image.png"},
         )
         responses.add(
             responses.PATCH,
-            "https://dev.azure.com/hanarero/Test/_apis/wit/workitems/123?api-version=7.1-preview.3",
+            f"https://dev.azure.com/{project}/_apis/wit/workitems/123?api-version=7.1-preview.3",
             json={"url": "https://store/image.png"},
         )
 

--- a/tests/backends/test_github.py
+++ b/tests/backends/test_github.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 def backend(rf, settings, admin_user):
     settings.ISSUES = {
         "OPTIONS": {
-            "API_TOKEN": os.environ["GITHUB_API_TOKEN"],
-            "PROJECT": os.environ["GITHUB_PROJECT"],
+            "API_TOKEN": os.environ.get("GITHUB_API_TOKEN", "token"),
+            "PROJECT": os.environ.get("GITHUB_PROJECT", "user/project"),
         }
     }
     req = rf.get("/test/", HTTP_REFERER="/from/")

--- a/tests/backends/test_gitlab.py
+++ b/tests/backends/test_gitlab.py
@@ -21,8 +21,8 @@ def screenshot(request, image):
 def backend(rf, settings, admin_user):
     settings.ISSUES = {
         "OPTIONS": {
-            "API_TOKEN": os.environ["GITLAB_API_TOKEN"],
-            "PROJECT": os.environ["GITLAB_PROJECT"],
+            "API_TOKEN": os.environ.get("GITLAB_API_TOKEN", "token"),
+            "PROJECT": os.environ.get("GITLAB_PROJECT", "user/project"),
         }
     }
     req = rf.get("/test/", HTTP_REFERER="/from/")

--- a/tox.ini
+++ b/tox.ini
@@ -22,14 +22,13 @@ extras =
 pass_env =
     CI
     DATABASE_URL
-    DEVOPS_PROJECT
-    DEVOPS_TOKEN
-    GITHUB_API_TOKEN
-    GITHUB_PROJECT
-    GITLAB_API_TOKEN
-    GITLAB_PROJECT
 set_env =
-    DEVOPS_TOKEN = {env:DEVOPS_TOKEN:.token}
+    DEVOPS_PROJECT = org/project
+    DEVOPS_TOKEN = token
+    GITHUB_API_TOKEN = token
+    GITHUB_PROJECT = org/project
+    GITLAB_API_TOKEN = token
+    GITLAB_PROJECT = org/project
     PYTHONDONTWRITEBYTECODE = 1
     PYTHONWARNINGS = ignore::DeprecationWarning
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -22,16 +22,16 @@ extras =
 pass_env =
     CI
     DATABASE_URL
+    DEVOPS_PROJECT
+    DEVOPS_TOKEN
     GITHUB_API_TOKEN
     GITHUB_PROJECT
     GITLAB_API_TOKEN
     GITLAB_PROJECT
 set_env =
-    CRYPT_KEYS = 123
-    CRYPT_SALT_KEYS = 123
+    DEVOPS_TOKEN = {env:DEVOPS_TOKEN:.token}
     PYTHONDONTWRITEBYTECODE = 1
     PYTHONWARNINGS = ignore::DeprecationWarning
-    SECRET_KEY = super-secret-key-just-for-testing
 commands =
     {posargs:pytest tests -rw --headless --cov-report=xml  --junit-xml=junit.xml -o junit_family=legacy}
 dependency_groups = dev

--- a/uv.lock
+++ b/uv.lock
@@ -575,6 +575,8 @@ type-check = [
     { name = "mypy", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mypy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "types-markdown" },
+    { name = "types-requests", version = "2.31.0.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "types-requests", version = "2.32.4.20250809", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.metadata]
@@ -628,6 +630,7 @@ type-check = [
     { name = "django-stubs", extras = ["compatible-mypy"] },
     { name = "mypy" },
     { name = "types-markdown" },
+    { name = "types-requests" },
 ]
 
 [[package]]
@@ -2417,6 +2420,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/90a442e538359ab5c9e30de415006fb22567aa4301c908c09f19e42975c2/types_pyyaml-6.0.12.20250822.tar.gz", hash = "sha256:259f1d93079d335730a9db7cff2bcaf65d7e04b4a56b5927d49a612199b59413", size = 17481, upload-time = "2025-08-22T03:02:16.209Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/8e/8f0aca667c97c0d76024b37cffa39e76e2ce39ca54a38f285a64e6ae33ba/types_pyyaml-6.0.12.20250822-py3-none-any.whl", hash = "sha256:1fe1a5e146aa315483592d292b72a172b65b946a6d98aa6ddd8e4aa838ab7098", size = 20314, upload-time = "2025-08-22T03:02:15.002Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.31.0.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "types-urllib3", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b8/c1e8d39996b4929b918aba10dba5de07a8b3f4c8487bb61bb79882544e69/types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0", size = 15535, upload-time = "2023-09-27T06:19:38.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/a1/6f8dc74d9069e790d604ddae70cb46dcbac668f1bb08136e7b0f2f5cd3bf/types_requests-2.31.0.6-py3-none-any.whl", hash = "sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9", size = 14516, upload-time = "2023-09-27T06:19:36.373Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20250809"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version >= '3.10' and python_full_version < '3.13'",
+]
+dependencies = [
+    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/b0/9355adb86ec84d057fea765e4c49cce592aaf3d5117ce5609a95a7fc3dac/types_requests-2.32.4.20250809.tar.gz", hash = "sha256:d8060de1c8ee599311f56ff58010fb4902f462a1470802cf9f6ed27bc46c4df3", size = 23027, upload-time = "2025-08-09T03:17:10.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/6f/ec0012be842b1d888d46884ac5558fd62aeae1f0ec4f7a581433d890d4b5/types_requests-2.32.4.20250809-py3-none-any.whl", hash = "sha256:f73d1832fb519ece02c85b1f09d5f0dd3108938e7d47e7f94bbfa18a6782b163", size = 20644, upload-time = "2025-08-09T03:17:09.716Z" },
+]
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239, upload-time = "2023-07-20T15:19:31.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377, upload-time = "2023-07-20T15:19:30.379Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  Adds a new backend for creating work items in Azure DevOps.

  The backend supports:
   - Creating work items with a title and description.
   - Uploading screenshots as attachments and linking them in the description.
   - Configuring the Azure DevOps server URL, project, and access token.

  The implementation uses the requests library to interact with the Azure DevOps API.

  Includes documentation and tests for the new backend.